### PR TITLE
Adjust group terminology and table notes

### DIFF
--- a/code/R code/balance.R
+++ b/code/R code/balance.R
@@ -162,17 +162,17 @@ table_body <- kable(final_table,
                     linesep  = "") %>%
   row_spec(1:(nrow(final_table)-1), extra_latex_after = "[1em]") %>%
   add_header_above(c(" " = 1,
-                     "Branches"    = 3,
+                     "Groups"      = 3,
                      "Differences" = 3))
 
 # 13. Write .tex file ----------------------------------------
 cat(
   "\\begin{table}[ht]
   \\centering
-  \\caption{Balance of Team-Level Characteristics by Branch}
+  \\caption{Balance of Team-Level Characteristics by Group}
   \\label{tab:balance_table}
   {\\scriptsize
 ", table_body, "}
-  \\multicolumn{7}{p{0.9\\textwidth}}{\\textit{Note:} Each cell in the first three columns shows the mean (top) and standard deviation (bottom) of the characteristic for the indicated branch. Cells in the last three columns show the mean difference between branches with the corresponding two-sided $t$-test $p$-value in parentheses.}
+  \\multicolumn{7}{p{0.9\\textwidth}}{\\textit{Note:} Each cell in the first three columns shows the mean (top) and standard deviation (bottom) of the characteristic for the indicated group. Cells in the last three columns show the mean difference between groups with the corresponding two-sided $t$-test $p$-value in parentheses.}
 \\end{table}",
   file = "output/tables/balance.tex")

--- a/code/R code/branches.R
+++ b/code/R code/branches.R
@@ -104,8 +104,8 @@ make_latex_table <- function(df, suffix = "", caption_add = "", label_add = "") 
         variable %in% c("Minutes to reproduction",
                         "Minutes to first minor error",
                         "Minutes to first major error"),
-        paste0(sprintf("%.1f", diff_mean), "<br>(", p_fmt, ")"),
-        paste0(sprintf("%.3f", diff_mean), "<br>(", p_fmt, ")")
+        paste0(sprintf("%.1f", diff_mean), "<br>[", p_fmt, "]"),
+        paste0(sprintf("%.3f", diff_mean), "<br>[", p_fmt, "]")
       ),
       comp_col = gsub(" vs ", "_", comparison)
     ) %>%
@@ -149,7 +149,7 @@ make_latex_table <- function(df, suffix = "", caption_add = "", label_add = "") 
     paste0("\\label{tab:comparison_metrics", label_add, "}\n"),
     "{\\scriptsize\n",
     table_body, "\n",
-    "\\multicolumn{7}{p{0.9\\textwidth}}{\\textit{Note:} Standard errors in parentheses for individual branches (Human-only, AI-Assisted, and AI-Led); p-values in parentheses for branch comparisons (Human-Only vs AI-Assisted, Human-Only vs AI-Led, and AI-Assisted vs AI-Led).}}\n",
+    "\\multicolumn{7}{p{0.9\\textwidth}}{\\textit{Note:} Columns 2--4 present means and standard errors in parentheses for individual groups (Human-only, AI-Assisted, and AI-Led); columns 5--7 present differences in means and p-values in brackets for group comparisons (Human-Only vs AI-Assisted, Human-Only vs AI-Led, and AI-Assisted vs AI-Led).}}\n",
     "\\end{table}",
     file = paste0("output/tables/branches", suffix, ".tex"))
 }

--- a/code/R code/error shares.R
+++ b/code/R code/error shares.R
@@ -147,7 +147,7 @@ print_full_latex_table <- function(resA,resB){
   cat(make_panel_latex(resB, "Panel B: Studies I and II combined"))
   cat("\\hline\\hline\n",
       "\\multicolumn{3}{l}{\\it{Note:} Standard errors in",
-      " parentheses, confidence intervals in brackets; human-only branch omitted.}\\\\\n",
+      " parentheses, confidence intervals in brackets; human-only group omitted.}\\\\\n",
       "\\multicolumn{3}{l}{Controls include number of teammates; game–software, skill, and attendance FEs.}\\\\\n",
       "\\multicolumn{3}{l}{\\sym{*} $p<0.1$, \\sym{**} $p<0.05$, \\sym{***} $p<0.01$}\\\\\n",
       "\\end{tabular}\n", sep=" ")

--- a/code/R code/full controls.R
+++ b/code/R code/full controls.R
@@ -138,7 +138,7 @@ make_full_latex_table <- function(tables, panel_name="") {
   out <- paste0(out, "p-val (AI-Assisted vs. AI-Led)&", paste(pvals, collapse="   &"), "   \\\\\n")
   out <- paste0(out, "Observations        &", paste(nobs, collapse="   &"), "   \\\\\n")
   out <- paste0(out, "\\hline\\hline\n")
-  out <- paste0(out, "\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only branch omitted.}\\\\\n")
+  out <- paste0(out, "\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted.}\\\\\n")
   out <- paste0(out, "\\multicolumn{8}{l}{\\sym{*} \\(p<0.1\\), \\sym{**} \\(p<0.05\\), \\sym{***} \\(p<0.01\\)}\\\\\n")
   out <- paste0(out, "\\end{tabular}\n")
   out

--- a/code/R code/gpt skill.R
+++ b/code/R code/gpt skill.R
@@ -197,7 +197,7 @@ cat(
 \\caption{AI-Assisted and AI-Led Metrics by Experience Level}
 \\label{tab:comparison_experience}
 \\tiny", table_body,"
-\\multicolumn{7}{p{0.9\\textwidth}}{\\it{Note:} Group columns display mean (SD). The two right-most columns show High – Low/Medium differences within each branch, with two-sided Welch \\emph{p}-values in parentheses.}
+\\multicolumn{7}{p{0.9\\textwidth}}{\\it{Note:} Group columns display mean (SD). The two right-most columns show High – Low/Medium differences within each group, with two-sided Welch \\emph{p}-values in parentheses.}
 \\end{table}",
   file = "output/tables/gpt skill.tex"
 )

--- a/code/R code/logit poisson.R
+++ b/code/R code/logit poisson.R
@@ -258,7 +258,7 @@ print_full_latex_table_poilog <- function(panelA_res, panelB_res) {
   cat("\\\\\n")
   cat(make_panel_latex_poilog(panelB_res, "Panel B: Studies I and II combined"))
   cat("\\hline\\hline\n")
-  cat("\\multicolumn{7}{p{0.8\\textwidth}}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only branch omitted. The model for One good robustness is not included due to insufficient observations, preventing it from converging. Marginal effects reported for Logit models.}\\\\\n")
+  cat("\\multicolumn{7}{p{0.8\\textwidth}}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted. The model for One good robustness is not included due to insufficient observations, preventing it from converging. Marginal effects reported for Logit models.}\\\\\n")
   cat("\\multicolumn{7}{l}{Controls include number of teammates; game--software, skill, and attendance fixed effects.}\\\\\n")
   cat("\\multicolumn{7}{l}{\\sym{*} \\(p<0.1\\), \\sym{**} \\(p<0.05\\), \\sym{***} \\(p<0.01\\)}\\\\\n")
   cat("\\end{tabular}\n")

--- a/code/R code/main.R
+++ b/code/R code/main.R
@@ -166,7 +166,7 @@ print_full_table <- function(A, B) {
   cat(make_panel_latex(B, "Panel B: Studies I and II combined"))
   cat("\\hline\\hline\n")
   cat("\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses; ",
-      "confidence intervals in brackets. Human-only branch omitted.}\\\\\n")
+      "confidence intervals in brackets. Human-only group omitted.}\\\\\n")
   cat("\\multicolumn{8}{l}{Controls: number of teammates; ",
       "game–software, skill, and attendance fixed effects.}\\\\\n")
   cat("\\multicolumn{8}{l}{\\sym{*} $p<0.10$, \\sym{**} $p<0.05$, ",

--- a/code/R code/master.R
+++ b/code/R code/master.R
@@ -60,8 +60,8 @@ cat("\n--- Main Table (Power) ---\n")
 source(here::here("code", "R code", "power.R"))
 rm(list = ls())
 
-# ---- 3. Branch Differences Table ----
-cat("\n--- Branch Differences Table ---\n")
+# ---- 3. Group Differences Table ----
+cat("\n--- Group Differences Table ---\n")
 source(here::here("code", "R code", "branches.R"))
 rm(list = ls())
 

--- a/code/R code/prompts.R
+++ b/code/R code/prompts.R
@@ -180,7 +180,7 @@ dir.create("output/tables", recursive = TRUE, showWarnings = FALSE)
 cat(
   "\\begin{table}[ht]
 \\centering
-\\caption{Comparison of Key Metrics by Prompt Levels within AI-Assisted Branch}
+\\caption{Comparison of Key Metrics by Prompt Levels within AI-Assisted Group}
 \\label{tab:comparison_metrics_prompts}
 {\\scriptsize", prompts_table_body,"
 \\multicolumn{4}{p{0.8\\textwidth}}{\\it{Note:} Group columns show mean (SD); the Difference column is Above − Below with a two-sided Welch

--- a/code/R code/softwares.R
+++ b/code/R code/softwares.R
@@ -141,7 +141,7 @@ print_full_latex_table_soft <- function(panelA_res, panelB_res) {
   cat("\\\\\n")
   cat(make_panel_latex_soft(panelB_res, "Panel B: Studies I and II combined"))
   cat("\\hline\\hline\n")
-  cat("\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only branch omitted; Stata papers omitted.}\\\\\n")
+  cat("\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted; Stata papers omitted.}\\\\\n")
   cat("\\multicolumn{8}{l}{Controls include number of teammates; game, skill, and attendance fixed effects.}\\\\\n")
   cat("\\multicolumn{8}{l}{\\sym{*} \\(p<0.1\\), \\sym{**} \\(p<0.05\\), \\sym{***} \\(p<0.01\\)}\\\\\n")
   cat("\\end{tabular}\n")

--- a/code/R code/study 2.R
+++ b/code/R code/study 2.R
@@ -146,7 +146,7 @@ writeLines(c(
   "\\hline",
   body,
   "\\hline\\hline",
-  "\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only branch omitted.}\\\\",
+  "\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted.}\\\\",
   "\\multicolumn{8}{l}{\\sym{*} \\(p<0.1\\), \\sym{**} \\(p<0.05\\), \\sym{***} \\(p<0.01\\)}\\\\",
   "\\end{tabular}"
 ), outfile)

--- a/code/Stata code/cleaning.do
+++ b/code/Stata code/cleaning.do
@@ -95,7 +95,7 @@ drop follow
 recode prompts files images words (.=0)
 
 label variable game "Game"
-label variable branch "Branch"
+label variable branch "Group"
 label variable team "Team"
 label variable paper "Paper"
 label variable paper_game "Paper in game"

--- a/code/Stata code/error shares.do
+++ b/code/Stata code/error shares.do
@@ -80,7 +80,7 @@ estout using "output/tables/error_shares.tex", 																///
       postfoot("\hline\hline"                                												///
                "\multicolumn{8}{l}{\it{Note:} Standard errors in " 											///
                "parentheses, confidence intervals in brackets; " 											///
-               "human-only branch omitted.}\\"               												///
+               "human-only group omitted.}\\"               												///
                "\multicolumn{8}{l}{Controls include number of "    											///
                "teammates; game–software, skill, and attendance "  											///
                "fixed effects.}\\"                           												///

--- a/code/Stata code/full controls.do
+++ b/code/Stata code/full controls.do
@@ -46,7 +46,7 @@ estout using "output/tables/full controls (s1).tex", ///
     posthead("\hline") ///
     prefoot("\hline") ///
     postfoot("\hline\hline" ///
-    "\multicolumn{8}{l}{\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only branch omitted.}\\" ///
+    "\multicolumn{8}{l}{\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted.}\\" ///
     "\multicolumn{8}{l}{\sym{*} \(p<0.1\), \sym{**} \(p<0.05\), \sym{***} \(p<0.01\)}\\" ///
     "\end{tabular}")
 
@@ -83,6 +83,6 @@ estout using "output/tables/full controls (s2).tex", ///
     posthead("\hline") ///
     prefoot("\hline") ///
     postfoot("\hline\hline" ///
-    "\multicolumn{8}{l}{\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only branch omitted.}\\" ///
+    "\multicolumn{8}{l}{\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted.}\\" ///
     "\multicolumn{8}{l}{\sym{*} \(p<0.1\), \sym{**} \(p<0.05\), \sym{***} \(p<0.01\)}\\" ///
     "\end{tabular}")

--- a/code/Stata code/logit poisson.do
+++ b/code/Stata code/logit poisson.do
@@ -113,7 +113,7 @@ estout using "output/tables/logit poisson.tex", append style(tex)  	///
     postfoot("\hline\hline"                                              	///
              "\multicolumn{7}{p{0.8\textwidth}}{\it{Note:} "            	///
              "Standard errors in parentheses, confidence intervals "     	///
-             "in brackets; human-only branch omitted. "						///
+             "in brackets; human-only group omitted. "						///
 			 "The model for One good robustness is not included "			///
 			 "due to unsuficient observations, preventing it from "			///
 			 "converging. Marginal effects reported for Logit models.}\\"   ///

--- a/code/Stata code/main.do
+++ b/code/Stata code/main.do
@@ -76,7 +76,7 @@ estout using "output/tables/main.tex", 																///
       postfoot("\hline\hline"                                												///
                "\multicolumn{8}{l}{\it{Note:} Standard errors in " 											///
                "parentheses, confidence intervals in brackets; " 											///
-               "human-only branch omitted.}\\"               												///
+               "human-only group omitted.}\\"               												///
                "\multicolumn{8}{l}{Controls include number of "    											///
                "teammates; game–software, skill, and attendance "  											///
                "fixed effects.}\\"                           												///

--- a/code/Stata code/master.do
+++ b/code/Stata code/master.do
@@ -60,7 +60,7 @@ q();
 END_OF_R
 
 
-**Branch differencess
+**Group differences
 rsource, terminator(END_OF_R) rpath("$rpath") ro(--vanilla)
 setwd("~/Dropbox/I4R/AI paper/R code")
 library(haven);

--- a/code/Stata code/prompt distribution.do
+++ b/code/Stata code/prompt distribution.do
@@ -3,7 +3,7 @@
 *********************************************************************/
 
 * -------------------------------------------------------------------
-* 1. Load data and keep only the AI-Assisted branch
+* 1. Load data and keep only the AI-Assisted group
 use "data/AI games.dta", clear
 keep if branch == 2
 

--- a/code/Stata code/softwares.do
+++ b/code/Stata code/softwares.do
@@ -82,7 +82,7 @@ estout using "output/tables/softwares.tex", append style(tex) 	///
     postfoot("\hline\hline"                                             		///
              "\multicolumn{8}{l}{\it{Note:} Standard errors in "        		///
              "parentheses, confidence intervals in brackets; "         			///
-             "human-only branch omitted; "				///
+             "human-only group omitted; "				///
 			 "Stata papers omitted.}\\" 		///
              "\multicolumn{8}{l}{Controls include number of teammates; " 		///
              "game, skill, and attendance fixed effects.}\\"           			///

--- a/code/Stata code/study 2.do
+++ b/code/Stata code/study 2.do
@@ -36,6 +36,6 @@ estout using "output/tables/study 2.tex", ///
     posthead("\hline") ///
     prefoot("\hline") ///
     postfoot("\hline\hline" ///
-    "\multicolumn{8}{l}{\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only branch omitted.}\\" ///
+    "\multicolumn{8}{l}{\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted.}\\" ///
     "\multicolumn{8}{l}{\sym{*} \(p<0.1\), \sym{**} \(p<0.05\), \sym{***} \(p<0.01\)}\\" ///
     "\end{tabular}")

--- a/code/Stata code/time to first.do
+++ b/code/Stata code/time to first.do
@@ -21,7 +21,7 @@ foreach var of local varlist {
     keep branch_team_n branch `var'
     rename `var' `var'_br
 
-    *** Reshape wide for each branch
+    *** Reshape wide for each group
     reshape wide `var'_br, i(branch_team_n) j(branch)
 
     *** Generate cumulative variables


### PR DESCRIPTION
## Summary
- clarify note and p-value brackets in comparison metrics table
- revise captions and notes for balance and other tables
- replace `branch` with `group` in various notes and comments across R and Stata code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684321e6b0408321bb77f0b26b572337