### PR TITLE
Clarify control variables in table notes

### DIFF
--- a/code/R code/error shares.R
+++ b/code/R code/error shares.R
@@ -148,7 +148,7 @@ print_full_latex_table <- function(resA,resB){
   cat("\\hline\\hline\n",
       "\\multicolumn{3}{l}{\\it{Note:} Standard errors in",
       " parentheses, confidence intervals in brackets; human-only group omitted.}\\\\\n",
-      "\\multicolumn{3}{l}{Controls include number of teammates; game–software, skill, and attendance FEs.}\\\\\n",
+      "\\multicolumn{3}{l}{Controls include number of teammates; game-by-software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\\\\\n",
       "\\multicolumn{3}{l}{\\sym{*} $p<0.1$, \\sym{**} $p<0.05$, \\sym{***} $p<0.01$}\\\\\n",
       "\\end{tabular}\n", sep=" ")
 }

--- a/code/R code/logit poisson.R
+++ b/code/R code/logit poisson.R
@@ -259,7 +259,7 @@ print_full_latex_table_poilog <- function(panelA_res, panelB_res) {
   cat(make_panel_latex_poilog(panelB_res, "Panel B: Studies I and II combined"))
   cat("\\hline\\hline\n")
   cat("\\multicolumn{7}{p{0.8\\textwidth}}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted. The model for One good robustness is not included due to insufficient observations, preventing it from converging. Marginal effects reported for Logit models.}\\\\\n")
-  cat("\\multicolumn{7}{l}{Controls include number of teammates; game--software, skill, and attendance fixed effects.}\\\\\n")
+  cat("\\multicolumn{7}{l}{Controls include number of teammates; game-by-software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\\\\\n")
   cat("\\multicolumn{7}{l}{\\sym{*} \\(p<0.1\\), \\sym{**} \\(p<0.05\\), \\sym{***} \\(p<0.01\\)}\\\\\n")
   cat("\\end{tabular}\n")
 }

--- a/code/R code/main.R
+++ b/code/R code/main.R
@@ -167,8 +167,7 @@ print_full_table <- function(A, B) {
   cat("\\hline\\hline\n")
   cat("\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses; ",
       "confidence intervals in brackets. Human-only group omitted.}\\\\\n")
-  cat("\\multicolumn{8}{l}{Controls: number of teammates; ",
-      "game–software, skill, and attendance fixed effects.}\\\\\n")
+  cat("\\multicolumn{8}{l}{Controls: number of teammates; game-by-software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\\\\\n")
   cat("\\multicolumn{8}{l}{\\sym{*} $p<0.10$, \\sym{**} $p<0.05$, ",
       "\\sym{***} $p<0.01$}\\\\\n")
   cat("\\end{tabular}\n")

--- a/code/R code/softwares.R
+++ b/code/R code/softwares.R
@@ -142,7 +142,7 @@ print_full_latex_table_soft <- function(panelA_res, panelB_res) {
   cat(make_panel_latex_soft(panelB_res, "Panel B: Studies I and II combined"))
   cat("\\hline\\hline\n")
   cat("\\multicolumn{8}{l}{\\it{Note:} Standard errors in parentheses, confidence intervals in brackets; human-only group omitted; Stata papers omitted.}\\\\\n")
-  cat("\\multicolumn{8}{l}{Controls include number of teammates; game, skill, and attendance fixed effects.}\\\\\n")
+  cat("\\multicolumn{8}{l}{Controls include number of teammates; game and software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\\\\\n")
   cat("\\multicolumn{8}{l}{\\sym{*} \\(p<0.1\\), \\sym{**} \\(p<0.05\\), \\sym{***} \\(p<0.01\\)}\\\\\n")
   cat("\\end{tabular}\n")
 }

--- a/code/Stata code/error shares.do
+++ b/code/Stata code/error shares.do
@@ -81,9 +81,7 @@ estout using "output/tables/error_shares.tex", 																///
                "\multicolumn{8}{l}{\it{Note:} Standard errors in " 											///
                "parentheses, confidence intervals in brackets; " 											///
                "human-only group omitted.}\\"               												///
-               "\multicolumn{8}{l}{Controls include number of "    											///
-               "teammates; game–software, skill, and attendance "  											///
-               "fixed effects.}\\"                           												///
+                 "\multicolumn{8}{l}{Controls include number of teammates; game, software, and game $\times$ software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\"                                     ///
                "\multicolumn{8}{l}{\sym{*} \(p<0.1\), \sym{**} \(p<0.05\), \sym{***} \(p<0.01\)}\\" 		///
                "\end{tabular}")                             												///
 	  prefoot("\hline")																						///

--- a/code/Stata code/logit poisson.do
+++ b/code/Stata code/logit poisson.do
@@ -117,8 +117,7 @@ estout using "output/tables/logit poisson.tex", append style(tex)  	///
 			 "The model for One good robustness is not included "			///
 			 "due to unsuficient observations, preventing it from "			///
 			 "converging. Marginal effects reported for Logit models.}\\"   ///
-             "\multicolumn{7}{l}{Controls include number of teammates; " 	///
-             "game–software, skill, and attendance fixed effects.}\\"    	///
+               "\multicolumn{7}{l}{Controls include number of teammates; game, software, and game $\times$ software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\"        ///
              "\multicolumn{7}{l}{\sym{*} \(p<0.1\), \sym{**} \(p<0.05\)," 	///
              " \sym{***} \(p<0.01\)}\\"                                  	///
              "\end{tabular}")                                            	///

--- a/code/Stata code/main.do
+++ b/code/Stata code/main.do
@@ -77,9 +77,7 @@ estout using "output/tables/main.tex", 																///
                "\multicolumn{8}{l}{\it{Note:} Standard errors in " 											///
                "parentheses, confidence intervals in brackets; " 											///
                "human-only group omitted.}\\"               												///
-               "\multicolumn{8}{l}{Controls include number of "    											///
-               "teammates; game–software, skill, and attendance "  											///
-               "fixed effects.}\\"                           												///
+                 "\multicolumn{8}{l}{Controls include number of teammates; game, software, and game $\times$ software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\"             ///
                "\multicolumn{8}{l}{\sym{*} \(p<0.1\), \sym{**} \(p<0.05\), \sym{***} \(p<0.01\)}\\" 		///
                "\end{tabular}")                             												///
 	  prefoot("\hline")																						///

--- a/code/Stata code/softwares.do
+++ b/code/Stata code/softwares.do
@@ -84,8 +84,7 @@ estout using "output/tables/softwares.tex", append style(tex) 	///
              "parentheses, confidence intervals in brackets; "         			///
              "human-only group omitted; "				///
 			 "Stata papers omitted.}\\" 		///
-             "\multicolumn{8}{l}{Controls include number of teammates; " 		///
-             "game, skill, and attendance fixed effects.}\\"           			///
+               "\multicolumn{8}{l}{Controls include number of teammates; game and software fixed effects; maximum and minimum position skill fixed effects; attendance fixed effects.}\"           ///
              "\multicolumn{8}{l}{\sym{*} \(p<0.1\), \sym{**} \(p<0.05\), " 		///
              "\sym{***} \(p<0.01\)}\\"                                			///
              "\end{tabular}")                                          			///


### PR DESCRIPTION
## Summary
- clarify the specific fixed effects and covariates used as controls in all table notes

## Testing
- `Rscript -e "cat('R works')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684344778aa48321952fbd24ee617677