### PR TITLE
Fix LaTeX break placeholder

### DIFF
--- a/code/R code/branches.R
+++ b/code/R code/branches.R
@@ -104,8 +104,8 @@ make_latex_table <- function(df, suffix = "", caption_add = "", label_add = "") 
         variable %in% c("Minutes to reproduction",
                         "Minutes to first minor error",
                         "Minutes to first major error"),
-        paste0(sprintf("%.1f", diff_mean), "<br>[", p_fmt, "]"),
-        paste0(sprintf("%.3f", diff_mean), "<br>[", p_fmt, "]")
+        paste0(sprintf("%.1f", diff_mean), "<br>\\relax[", p_fmt, "]"),
+        paste0(sprintf("%.3f", diff_mean), "<br>\\relax[", p_fmt, "]")
       ),
       comp_col = gsub(" vs ", "_", comparison)
     ) %>%


### PR DESCRIPTION
## Summary
- avoid LaTeX math delimiter issues in `branches.R` by inserting `\relax`

## Testing
- `grep -n '<br>' code/R\ code/branches.R`

------
https://chatgpt.com/codex/tasks/task_e_68470afb45fc8321b3b08e20c01a9808