### PR TITLE
Fix p-value formatting in tables

### DIFF
--- a/code/R code/balance.R
+++ b/code/R code/balance.R
@@ -126,7 +126,8 @@ diff_df <- diff_df %>%
   mutate(p_fmt = ifelse(is.na(p_value),"NA",
                         ifelse(p_value<0.001,"\\textless0.001",
                                sprintf("%.3f",p_value))),
-         diff_p = paste0(sprintf("%.3f", diff_mean), "<br>(", p_fmt, ")"),
+         # Add \relax so [ is not parsed as an optional argument
+         diff_p = paste0(sprintf("%.3f", diff_mean), "<br>\\relax[", p_fmt, "]"),
          comp_col = gsub(" vs ", "_", comparison)) %>%
   dplyr::select(variable, comp_col, diff_p) %>%
   pivot_wider(names_from = comp_col, values_from = diff_p)
@@ -173,6 +174,6 @@ cat(
   \\label{tab:balance_table}
   {\\scriptsize
 ", table_body, "}
-  \\multicolumn{7}{p{0.9\\textwidth}}{\\textit{Note:} Each cell in the first three columns shows the mean (top) and standard deviation (bottom) of the characteristic for the indicated group. Cells in the last three columns show the mean difference between groups with the corresponding two-sided $t$-test $p$-value in parentheses.}
+  \multicolumn{7}{p{0.9\textwidth}}{\textit{Note:} Columns 2--4 present means and standard errors in parentheses for individual groups (Human-only, AI-Assisted, and AI-Led); the difference columns show mean differences and $p$-values in brackets for the indicated group comparisons.}
 \\end{table}",
   file = "output/tables/balance.tex")

--- a/code/R code/gpt skill.R
+++ b/code/R code/gpt skill.R
@@ -115,7 +115,8 @@ fmt_diff_p <- function(diff, p, minutes = FALSE){
   diff_out <- ifelse(minutes, sprintf("%.1f", diff), sprintf("%.3f", diff))
   p_out    <- ifelse(is.na(p), "NA",
                      ifelse(p < 0.001, "<0.001", sprintf("%.3f", p)))
-  paste0(diff_out, "<br>(", p_out, ")")
+  # Add \relax so [ is not parsed as an optional argument
+  paste0(diff_out, "<br>\\relax[", p_out, "]")
 }
 
 diff_df <- diff_list %>% 
@@ -197,7 +198,6 @@ cat(
 \\caption{AI-Assisted and AI-Led Metrics by Experience Level}
 \\label{tab:comparison_experience}
 \\tiny", table_body,"
-\\multicolumn{7}{p{0.9\\textwidth}}{\\it{Note:} Group columns display mean (SD). The two right-most columns show High – Low/Medium differences within each group, with two-sided Welch \\emph{p}-values in parentheses.}
+\multicolumn{7}{p{0.9\textwidth}}{\it{Note:} Columns 2--5 present means and standard errors in parentheses for individual groups (Human-only, AI-Assisted, and AI-Led); the difference columns show mean differences and $p$-values in brackets for the indicated group comparisons.}
 \\end{table}",
-  file = "output/tables/gpt skill.tex"
 )

--- a/code/R code/prompts.R
+++ b/code/R code/prompts.R
@@ -119,7 +119,8 @@ diff_p_df <- diff_p_df %>%
     p_fmt    = ifelse(is.na(pval), "NA",
                       ifelse(pval < 0.001, "<0.001",
                              sprintf("%.3f", pval))),
-    diff_p   = paste0(diff_fmt, "<br>(", p_fmt, ")")
+    # Add \relax so [ is not parsed as an optional argument
+    diff_p   = paste0(diff_fmt, "<br>\\relax[", p_fmt, "]")
   ) %>% 
   dplyr::select(variable, diff_p)    # ← note the namespace
 
@@ -183,8 +184,7 @@ cat(
 \\caption{Comparison of Key Metrics by Prompt Levels within AI-Assisted Group}
 \\label{tab:comparison_metrics_prompts}
 {\\scriptsize", prompts_table_body,"
-\\multicolumn{4}{p{0.8\\textwidth}}{\\it{Note:} Group columns show mean (SD); the Difference column is Above − Below with a two-sided Welch
-\\emph{p}-value in parentheses. Groups are defined by the median number of prompts (", prompts_median, ") in the AI-Assisted sample.}}
+\multicolumn{4}{p{0.8\textwidth}}{\it{Note:} Columns 2--3 present means and standard errors in parentheses for individual groups (Human-only, AI-Assisted, and AI-Led); the Difference column shows mean differences and $p$-values in brackets for the indicated group comparison. Groups are defined by the median number of prompts (", prompts_median, ") in the AI-Assisted sample.}}
 \\end{table}",
   file = "output/tables/prompts.tex"
 )


### PR DESCRIPTION
## Summary
- update difference columns to show p-values in brackets
- prepend `\relax` after LaTeX line breaks
- revise table notes to describe new formatting

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68471435e078832192fe011ac850f954